### PR TITLE
feat: add markdown highlighting for .clinerules files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    ".clinerules": "markdown"
+  }
+}


### PR DESCRIPTION
# .clinerules ファイルのMarkdownハイライト設定

## 変更内容
- .clinerules ファイルをMarkdownとして認識するようVSCode設定を追加
- GitHub Codespacesを含む全ての環境で一貫した表示を実現

## 動作確認方法
1. このブランチをチェックアウト
2. .clinerules ファイルをVSCodeで開く
3. Markdownのシンタックスハイライトが適用されていることを確認