### PR TITLE
在庫表示用の丸印の視認性を向上

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,10 +33,10 @@
     --nav-bg: 0 0% 96%;
     --nav-border: 0 0% 85%;
     --item-alt-bg: 0 0% 98%;
-    --unopened-bg: 142 52% 96%;
-    --unopened-border: 142 52% 80%;
-    --opened-bg: 48 100% 96%;
-    --opened-border: 48 100% 80%;
+    --unopened-bg: 142 70% 85%;
+    --unopened-border: 142 70% 60%;
+    --opened-bg: 48 100% 85%;
+    --opened-border: 48 100% 60%;
   }
 
   .dark {

--- a/src/components/features/item-card.tsx
+++ b/src/components/features/item-card.tsx
@@ -11,14 +11,14 @@ export default function ItemCard({ item, isAlternate = false }: ItemCardProps) {
   // 未開封アイテムの丸を生成
   const renderUnopenedDots = () => {
     return Array.from({ length: item.unopenedCount }).map((_, index) => (
-      <div key={`unopened-${index}`} className="w-7 h-7 rounded-full unopened-dot"></div>
+      <div key={`unopened-${index}`} className="w-7 h-7 rounded-full unopened-dot border-2"></div>
     ));
   };
 
   // 開封済みアイテムの丸を生成
   const renderOpenedDots = () => {
     return Array.from({ length: item.openedCount }).map((_, index) => (
-      <div key={`opened-${index}`} className="w-7 h-7 rounded-full opened-dot"></div>
+      <div key={`opened-${index}`} className="w-7 h-7 rounded-full opened-dot border-2"></div>
     ));
   };
 


### PR DESCRIPTION
## Summary
- 未開封・開封済みの丸印の色をより濃い色に変更し視認性を向上
- ボーダーを太くして（border-2）丸印の視認性を向上

## Test plan
- アプリケーションを起動し、在庫管理画面で丸印が見やすくなっていることを確認
- 未開封アイテム（緑色）と開封済みアイテム（黄色）の両方が明確に視認できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)